### PR TITLE
Support id3v2Version arg in MPEG::File::save for Taglib >=1.8

### DIFF
--- a/src/wrapper/id3.cpp
+++ b/src/wrapper/id3.cpp
@@ -86,7 +86,11 @@ namespace
   // -------------------------------------------------------------
   // MPEG
   // -------------------------------------------------------------
-  MF_OL(save, 0, 2)
+  #if (TAGPY_TAGLIB_HEX_VERSION >= 0x10800)
+    MF_OL(save, 0, 3)
+  #else
+    MF_OL(save, 0, 2)
+  #endif
   MF_OL(ID3v1Tag, 0, 1)
   MF_OL(ID3v2Tag, 0, 1)
   MF_OL(APETag, 0, 1)
@@ -416,7 +420,11 @@ void exposeID3()
        init<const char *, optional<bool, AudioProperties::ReadStyle> >())
       .def(init<const char *, ID3v2::FrameFactory *, optional<bool, AudioProperties::ReadStyle> >())
       .def("save",
-           (bool (MPEG::File::*)(int, bool))
+           #if (TAGPY_TAGLIB_HEX_VERSION >= 0x10800)
+             (bool (MPEG::File::*)(int, bool, int))
+           #else
+             (bool (MPEG::File::*)(int, bool))
+           #endif
            &cl::save,
            save_overloads())
       .def("ID3v1Tag",


### PR DESCRIPTION
This _should_ fix #2.  (It works for me, at least.)

Please note that my C++ is _very_ rusty and I know practically nothing about using Boost, so I may have screwed up here.  :-)
